### PR TITLE
Stubbing out possible declaration of key-to-value association via generic types

### DIFF
--- a/src/LazyMap/AbstractLazyMap.php
+++ b/src/LazyMap/AbstractLazyMap.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace LazyMap;
 
 /**
- * @psalm-template T
+ * @psalm-template KeyType of string
+ * @psalm-template ValueType
  */
 abstract class AbstractLazyMap
 {
@@ -14,7 +15,8 @@ abstract class AbstractLazyMap
      *
      * @return mixed reference to the instantiated property
      *
-     * @psalm-return T
+     * @psalm-param KeyType $name
+     * @psalm-return ValueType
      * @psalm-suppress MixedInferredReturnType
      */
     public function & __get(string $name)
@@ -30,7 +32,8 @@ abstract class AbstractLazyMap
      *
      * @return mixed
      *
-     * @psalm-return T
+     * @psalm-param KeyType $name
+     * @psalm-return ValueType
      */
     abstract protected function instantiate(string $name);
 }

--- a/src/LazyMap/CallbackLazyMap.php
+++ b/src/LazyMap/CallbackLazyMap.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace LazyMap;
 
 /**
- * @psalm-template T
- * @template-extends AbstractLazyMap<T>
+ * @psalm-template KeyType of string
+ * @psalm-template ValueType
+ * @template-extends AbstractLazyMap<KeyName, ValueType>
  */
 final class CallbackLazyMap extends AbstractLazyMap
 {
     /**
-     * @psalm-param callable(string) : T $callback
+     * @psalm-param callable(KeyType) : ValueType $callback
      */
     public function __construct(callable $callback)
     {
@@ -19,11 +20,12 @@ final class CallbackLazyMap extends AbstractLazyMap
     }
 
     /**
-     * {@inheritDoc}
+     * @psalm-param KeyType $name
+     * @psalm-return ValueType
      */
-    protected function instantiate(string $name)
+    private function instantiate(string $name)
     {
-        /** @psalm-var callable(string) : T $callback */
+        /** @psalm-var callable(KeyType) : ValueType $callback */
         $callback = $this->{self::class . "\0callback"};
 
         return $callback($name);

--- a/src/LazyMap/CallbackLazyMap.php
+++ b/src/LazyMap/CallbackLazyMap.php
@@ -7,7 +7,7 @@ namespace LazyMap;
 /**
  * @psalm-template KeyType of string
  * @psalm-template ValueType
- * @template-extends AbstractLazyMap<KeyName, ValueType>
+ * @template-extends AbstractLazyMap<KeyType, ValueType>
  */
 final class CallbackLazyMap extends AbstractLazyMap
 {
@@ -23,7 +23,7 @@ final class CallbackLazyMap extends AbstractLazyMap
      * @psalm-param KeyType $name
      * @psalm-return ValueType
      */
-    private function instantiate(string $name)
+    protected function instantiate(string $name)
     {
         /** @psalm-var callable(KeyType) : ValueType $callback */
         $callback = $this->{self::class . "\0callback"};

--- a/src/LazyMap/CallbackLazyMap.php
+++ b/src/LazyMap/CallbackLazyMap.php
@@ -12,11 +12,27 @@ namespace LazyMap;
 final class CallbackLazyMap extends AbstractLazyMap
 {
     /**
+     * This is a trade-off: the callback lazy map was designed to
+     * have no accessible properties for its internal details, but
+     * somebody requesting explicitly for the key "internalCallbackDoNotReferenceThisThereWillBeDragons"
+     * is indeed looking for trouble.
+     *
+     * The initial design used a key with a "\0" in its name, but
+     * that was too hacky and led to optimizations and type inference
+     * problems that are not worth the added safety.
+     *
+     * @var callable
+     *
+     * @psalm-var callable(KeyType) : ValueType
+     */
+    private $internalCallbackDoNotReferenceThisThereWillBeDragons;
+
+    /**
      * @psalm-param callable(KeyType) : ValueType $callback
      */
     public function __construct(callable $callback)
     {
-        $this->{self::class . "\0callback"} = $callback;
+        $this->internalCallbackDoNotReferenceThisThereWillBeDragons = $callback;
     }
 
     /**
@@ -25,9 +41,6 @@ final class CallbackLazyMap extends AbstractLazyMap
      */
     protected function instantiate(string $name)
     {
-        /** @psalm-var callable(KeyType) : ValueType $callback */
-        $callback = $this->{self::class . "\0callback"};
-
-        return $callback($name);
+        return ($this->internalCallbackDoNotReferenceThisThereWillBeDragons)($name);
     }
 }

--- a/test/LazyMapTest/AbstractLazyMapTest.php
+++ b/test/LazyMapTest/AbstractLazyMapTest.php
@@ -22,7 +22,7 @@ class AbstractLazyMapTest extends TestCase
 
     public function testDirectPropertyAccess() : void
     {
-        /** @psalm-var AbstractLazyMap<string>&MockObject $lazyMap */
+        /** @psalm-var AbstractLazyMap<string, string>&MockObject $lazyMap */
         $lazyMap = $this->lazyMap;
 
         $lazyMap
@@ -40,7 +40,7 @@ class AbstractLazyMapTest extends TestCase
 
     public function testMultipleDirectPropertyAccessDoesNotTriggerSameInstantiation() : void
     {
-        /** @psalm-var AbstractLazyMap<stdClass>&MockObject $lazyMap */
+        /** @psalm-var AbstractLazyMap<string, stdClass>&MockObject $lazyMap */
         $lazyMap = $this->lazyMap;
 
         $lazyMap
@@ -64,7 +64,7 @@ class AbstractLazyMapTest extends TestCase
 
     public function testUnSettingPropertiesRemovesSharedInstance() : void
     {
-        /** @psalm-var AbstractLazyMap<stdClass>&MockObject $lazyMap */
+        /** @psalm-var AbstractLazyMap<string, stdClass>&MockObject $lazyMap */
         $lazyMap = $this->lazyMap;
 
         $lazyMap

--- a/test/LazyMapTest/CallbackLazyMapTest.php
+++ b/test/LazyMapTest/CallbackLazyMapTest.php
@@ -6,6 +6,8 @@ namespace LazyMapTest;
 
 use LazyMap\CallbackLazyMap;
 use LazyMapTestAsset\CallableClass;
+use LazyMapTestAsset\InstantiableClassA;
+use LazyMapTestAsset\InstantiableClassB;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -43,5 +45,31 @@ class CallbackLazyMapTest extends TestCase
         self::assertEquals('foo - 1', $this->lazyMap->foo);
         self::assertEquals('bar - 2', $this->lazyMap->bar);
         self::assertEquals('baz\\tab - 3', $this->lazyMap->{'baz\\tab'});
+    }
+
+    public function testCanActAsFactoryForDynamicTypes() : void
+    {
+        $map = new CallbackLazyMap([self::class, 'makeInstanceByClassName']);
+
+        self::assertSame(
+            InstantiableClassA::class,
+            $map->{InstantiableClassA::class}
+                ->getClassName()
+        );
+        self::assertSame(
+            InstantiableClassB::class,
+            $map->{InstantiableClassB::class}
+                ->getClassName()
+        );
+    }
+
+    /**
+     * @psalm-template InstanceType of object
+     * @psalm-param class-string<InstanceType> $className
+     * @psalm-return InstanceType
+     */
+    public static function makeInstanceByClassName(string $className) : object
+    {
+        return new $className();
     }
 }

--- a/test/LazyMapTestAsset/InstantiableClassA.php
+++ b/test/LazyMapTestAsset/InstantiableClassA.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LazyMapTestAsset;
+
+final class InstantiableClassA
+{
+    public function getClassName() : string
+    {
+        return self::class;
+    }
+}

--- a/test/LazyMapTestAsset/InstantiableClassB.php
+++ b/test/LazyMapTestAsset/InstantiableClassB.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LazyMapTestAsset;
+
+final class InstantiableClassB
+{
+    public function getClassName() : string
+    {
+        return self::class;
+    }
+}

--- a/test/LazyMapTestAsset/NullLazyMap.php
+++ b/test/LazyMapTestAsset/NullLazyMap.php
@@ -9,7 +9,7 @@ use LazyMap\AbstractLazyMap;
 /**
  * Example lazy map producing only null values
  *
- * @template-extends AbstractLazyMap<null>
+ * @template-extends AbstractLazyMap<string, null>
  */
 class NullLazyMap extends AbstractLazyMap
 {


### PR DESCRIPTION
This is just a stub - I was trying to make it work, but we need following first:

 * [x] https://github.com/vimeo/psalm/issues/1999
 * [ ] https://github.com/vimeo/psalm/issues/2897